### PR TITLE
Added Set-NPSCertificate to install certificates into NPS Network Policies

### DIFF
--- a/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
+++ b/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
@@ -18,6 +18,7 @@ FunctionsToExport = @(
     'Set-RDGWCertificate'
     'Set-RDSHCertificate'
     'Set-WinRMCertificate'
+    'Set-NPSCertificate'
 )
 CmdletsToExport = @()
 VariablesToExport = @()

--- a/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
@@ -8,6 +8,7 @@ function Set-NPSCertificate {
       [string]$PfxFile,
       [Parameter(Position=2,ValueFromPipelineByPropertyName)]
       [securestring]$PfxPass,
+      [string]$IASConfigPath = '%SystemRoot%\System32\ias\ias.xml',
       [Parameter(Mandatory=$true)]
       [string]$PolicyName,
       [switch]$RemoveOldCert
@@ -25,7 +26,7 @@ function Set-NPSCertificate {
           }
       }
 
-      [xml]$IASConfig = get-content 'C:\Windows\System32\ias\ias.xml'
+      [xml]$IASConfig = Get-Content ([Environment]::ExpandEnvironmentVariables($IASConfigPath))
 
       $policy = $IASConfig.SelectSingleNode("//RadiusProfiles//*[@name='$PolicyName']")
       
@@ -46,7 +47,7 @@ function Set-NPSCertificate {
         Write-Verbose "Setting $PolicyName certificate thumbprint to $CertThumbprint"
         $policy.Properties.msEAPConfiguration.InnerText = $policy.Properties.msEAPConfiguration.InnerText.SubString(0,72) + $CertThumbprint.ToLower() + $policy.Properties.msEAPConfiguration.InnerText.SubString(112)
         
-        $IASConfig.Save('C:\Windows\System32\ias\ias.xml')
+        $IASConfig.Save([Environment]::ExpandEnvironmentVariables($IASConfigPath))
 
         Restart-Service 'IAS'
         

--- a/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
@@ -80,6 +80,9 @@ function Set-NPSCertificate {
   .PARAMETER PfxPass
       The export password for the specified PfxFile parameter. Not required if the Pfx does not require an export password.
 
+  .PARAMETER IASConfigPath
+      The path to the NPS config file you want to edit. Default: %SystemRoot%\System32\ias\ias.xml
+  
   .PARAMETER PolicyName
       The name of the Network Policy.
 

--- a/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-NPSCertificate.ps1
@@ -1,0 +1,102 @@
+function Set-NPSCertificate {
+  [CmdletBinding()]
+  param(
+      [Parameter(Mandatory,Position=0,ValueFromPipelineByPropertyName)]
+      [Alias('Thumbprint')]
+      [string]$CertThumbprint,
+      [Parameter(Position=1,ValueFromPipelineByPropertyName)]
+      [string]$PfxFile,
+      [Parameter(Position=2,ValueFromPipelineByPropertyName)]
+      [securestring]$PfxPass,
+      [Parameter(Mandatory=$true)]
+      [string]$PolicyName,
+      [switch]$RemoveOldCert
+  )
+
+  Process {
+
+      # install the cert if necessary
+      if (-not (Test-CertInstalled $CertThumbprint)) {
+          if ($PfxFile) {
+              $PfxFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PfxFile)
+              Import-PfxCertInternal $PfxFile -PfxPass $PfxPass
+          } else {
+              throw "Certificate thumbprint not found and PfxFile not specified."
+          }
+      }
+
+      [xml]$IASConfig = get-content 'C:\Windows\System32\ias\ias.xml'
+
+      $policy = $IASConfig.SelectSingleNode("//RadiusProfiles//*[@name='$PolicyName']")
+      
+      # verify the policy exists
+      if (-not ($policy)) {
+          throw "Policy $PolicyName not found."
+      }
+
+      $currentThumb = $policy.Properties.msEAPConfiguration.InnerText.Substring(72,40)
+      
+      # update the cert thumbprint if it's different
+      if ($CertThumbprint -ne $currentThumb) {
+
+        # save the old thumbprint
+        $oldThumb = $currentThumb
+
+        # set the new one
+        Write-Verbose "Setting $PolicyName certificate thumbprint to $CertThumbprint"
+        $policy.Properties.msEAPConfiguration.InnerText = $policy.Properties.msEAPConfiguration.InnerText.SubString(0,72) + $CertThumbprint.ToLower() + $policy.Properties.msEAPConfiguration.InnerText.SubString(112)
+        
+        $IASConfig.Save('C:\Windows\System32\ias\ias.xml')
+
+        Restart-Service 'IAS'
+        
+        # remove the old cert if specified
+        if ($RemoveOldCert) { Remove-OldCert $oldThumb }
+
+      } else {
+          Write-Warning "Specified certificate is already configured for NPS Policy $PolicyName"
+      }
+
+  }
+
+
+
+
+
+  <#
+  .SYNOPSIS
+      Configure a NPS Network Policy to use the specified certificate for MS PEAP.
+
+  .DESCRIPTION
+      Intended to be used with the output from Posh-ACME's New-PACertificate or Submit-Renewal.
+
+  .PARAMETER CertThumbprint
+      Thumbprint/Fingerprint for the certificate to configure.
+
+  .PARAMETER PfxFile
+      Path to a PFX containing a certificate and private key. Not required if the certificate is already in the local system's Personal certificate store.
+
+  .PARAMETER PfxPass
+      The export password for the specified PfxFile parameter. Not required if the Pfx does not require an export password.
+
+  .PARAMETER PolicyName
+      The name of the Network Policy.
+
+  .PARAMETER RemoveOldCert
+      If specified, the old certificate associated with RDP will be deleted from the local system's Personal certificate store. Ignored if the old certificate has already been removed or otherwise can't be found.
+
+  .EXAMPLE
+      New-PACertificate site1.example.com | Set-NPSCertificate -PolicyName "Secure Wireless Connections"
+
+      Create a new certificate and add it to the specified NPS Network Policy.
+
+  .EXAMPLE
+      Submit-Renewal site1.example.com | Set-NPSCertificate -PolicyName "Secure Wireless Connections"
+
+      Renew a certificate and and add it to the specified NPS Network Policy.
+
+  .LINK
+      Project: https://github.com/rmbolger/Posh-ACME.Deploy
+
+  #>
+}


### PR DESCRIPTION
This will update the XML config for Network Policy Server and then restart the service.

Direct editing is the only way I could find as there isn't much support for Powershell in NPS.

It hasn't been extensively testing but seems to work with the limited testing I have done.