### PR TITLE
Correct loading logic for Exchange Powershell snapin

### DIFF
--- a/Posh-ACME.Deploy/Public/Set-ExchangeCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ExchangeCertificate.ps1
@@ -14,17 +14,20 @@ function Set-ExchangeCertificate {
 
     Process {
 
-        # make sure the Exchange snapin is available
-        if (!(Get-PSSnapin | Where-Object { $_.Name -match "Microsoft.Exchange.Management.PowerShell" })) {
+        # make sure the Exchange snapin is available on the local system
+        if (!(Get-PSSnapin -Registered | Where-Object { $_.Name -match "Microsoft.Exchange.Management.PowerShell" })) {
             throw "The Microsoft.Exchange.Management.PowerShell snapin is required to use this function."
         } else {
-            Get-PSSnapin -Registered | Where-Object {
-                $_.Name -match "Microsoft.Exchange.Management.PowerShell" -and (
-                    $_.Name -match "Admin" -or
-                    $_.Name -match "E2010" -or
-                    $_.Name -match "SnapIn"
-                )
-            } | Add-PSSnapin -EA SilentlyContinue
+            # if it's not already loaded
+            if (!(Get-PSSnapin | Where-Object {
+                  $_.Name -match "Microsoft.Exchange.Management.PowerShell" -and (
+                      $_.Name -match "Admin" -or
+                      $_.Name -match "E2010" -or
+                      $_.Name -match "SnapIn"
+                  )
+            })) { # load it
+                 Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn
+                 }
         }
 
         # install the cert if necessary


### PR DESCRIPTION
It seemed that the intent of the original logic was to allow the Exchange 
snapin to be loaded externally or previously and if it hasn't yet been 
loaded, then do it automatically.

The original code didn't quite achieve this, there were two errors:
1) The test of the existence somewhere on the machine for the Exchange snapin should be a -Registered check, but it was coded as without -Registered and thus only succeeded if the snapin was previously loaded.
2) The second check should have tested whether it had been loaded, but it merely tested to see if it existed (-Registered) and thus always attempted to load the snapin which resulted in messages about it already being loaded.