### PR TITLE
Manage Install and Removal of Exchange certificate consistently

### DIFF
--- a/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
+++ b/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
@@ -15,6 +15,7 @@ FunctionsToExport = @(
     'Set-IISCertificate'
     'Set-IISCertificateNew'
     'Set-IISFTPCertificate'
+    'Set-RASSTPCertificate'
     'Set-RDGWCertificate'
     'Set-RDSHCertificate'
     'Set-WinRMCertificate'

--- a/Posh-ACME.Deploy/Private/Confirm-CertInstall.ps1
+++ b/Posh-ACME.Deploy/Private/Confirm-CertInstall.ps1
@@ -17,17 +17,11 @@ function Confirm-CertInstall {
             throw "CertThumbprint and PfxFile were not provided. You must specify one or both of them."
         }
 
-        # grab the cert thumbprint from the PFX file if it wasn't specified
-        if (-not $CertThumbprint) {
-            Write-Verbose "Attempting to read Pfx thumbprint"
-            $CertThumbprint = Get-PfxThumbprint -PfxFile $PfxFile -PfxPass $PfxPass
-        }
-
         # install the cert if necessary
         if (-not (Test-CertInstalled $CertThumbprint)) {
-            if ($PfxFile) {
+            if ($PfxFile) {# grab the cert thumbprint from the PFX file if it wasn't valid/installed
                 $PfxFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($PfxFile)
-                Import-PfxCertInternal $PfxFile -PfxPass $PfxPass
+                $CertThumbprint = Import-PfxCertInternal $PfxFile -PfxPass $PfxPass
             } else {
                 throw "Certificate thumbprint not found and no PfxFile file specified to import."
             }

--- a/Posh-ACME.Deploy/Private/Confirm-CertInstall.ps1
+++ b/Posh-ACME.Deploy/Private/Confirm-CertInstall.ps1
@@ -1,8 +1,10 @@
 function Confirm-CertInstall {
     param(
         [Parameter(Position=0)]
+        [AllowEmptyString()]
         [string]$CertThumbprint,
         [Parameter(Position=1)]
+        [AllowEmptyString()]
         [string]$PfxFile,
         [Parameter(Position=2)]
         [securestring]$PfxPass,

--- a/Posh-ACME.Deploy/Private/Import-PfxCertInternal.ps1
+++ b/Posh-ACME.Deploy/Private/Import-PfxCertInternal.ps1
@@ -24,6 +24,7 @@ function Import-PfxCertInternal {
         $PfxPass = New-Object Security.SecureString
     }
 
+    $Thumbprint = ''
     if ($PSVersionTable.PSEdition -eq 'Core' -and !$IsWindows) {
         # This is a non-Windows version of PowerShell Core
         throw "Certificate import is not currently supported on non-Windows OSes"
@@ -60,8 +61,13 @@ function Import-PfxCertInternal {
 
         } finally {
             if ($null -ne $store) { $store.Dispose() }
-            if ($null -ne $pfx) { $pfx.Dispose() }
+            if ($null -ne $pfx) {
+                $Thumbprint = $pfx.Thumbprint
+                $pfx.Dispose()
+            }
         }
+
+    return $Thumbprint
 
     }
 

--- a/Posh-ACME.Deploy/Private/Test-CertInstalled.ps1
+++ b/Posh-ACME.Deploy/Private/Test-CertInstalled.ps1
@@ -3,6 +3,7 @@ function Test-CertInstalled {
     param(
         [Parameter(Mandatory,Position=0,ValueFromPipelineByPropertyName)]
         [Alias('Thumbprint')]
+        [AllowEmptyString()]
         [string]$CertThumbprint,
         [Parameter(Position=1)]
         [ValidateSet('LocalMachine','CurrentUser')]
@@ -10,6 +11,10 @@ function Test-CertInstalled {
         [Parameter(Position=2)]
         [string]$StoreName = 'My'
     )
+
+    if (-not $CertThumbprint) {
+        return $false
+    }
 
     $allCerts = Get-ChildItem Cert:\$StoreLocation\$StoreName
 

--- a/Posh-ACME.Deploy/Public/Set-ExchangeCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ExchangeCertificate.ps1
@@ -8,26 +8,25 @@ function Set-ExchangeCertificate {
         [string]$PfxFile,
         [Parameter(Position=2,ValueFromPipelineByPropertyName)]
         [securestring]$PfxPass,
-        [string[]]$ExchangeServices=@('IIS','SMTP'),
+        [string[]]$ExchangeServices=@('IMAP', 'POP', 'IIS','SMTP'),
         [switch]$RemoveOldCert
     )
 
     Begin {
+    
         # make sure the Exchange snapin is available on the local system
         if (!(Get-PSSnapin -Registered | Where-Object { $_.Name -match "Microsoft.Exchange.Management.PowerShell" })) {
-            try { throw "The Microsoft.Exchange.Management.PowerShell snapin is required to use this function." }
-            catch { $PSCmdlet.ThrowTerminatingError($_) }
+            throw "The Microsoft.Exchange.Management.PowerShell snapin is required to use this function."
         } else {
-            # if it's not already loaded
             if (!(Get-PSSnapin | Where-Object {
                   $_.Name -match "Microsoft.Exchange.Management.PowerShell" -and (
                       $_.Name -match "Admin" -or
                       $_.Name -match "E2010" -or
                       $_.Name -match "SnapIn"
                   )
-            })) { # load it
-                Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn
-            }
+            })) {
+                 Add-PSSnapin Microsoft.Exchange.Management.PowerShell.SnapIn
+                 }
         }
     }
 
@@ -38,23 +37,67 @@ function Set-ExchangeCertificate {
 
         $CertThumbprint = Confirm-CertInstall @PSBoundParameters
 
-        # check the old thumbprint value
-        $oldThumbs = ($ExchangeServices | ForEach-Object {
-            $service = $_
-            (Get-ExchangeCertificate | Where-Object { $service -in ($_.Services -split ', ') }).Thumbprint
-        } | Sort-Object -Unique)
+        $Cert = Get-ChildItem -Path "Cert:\LocalMachine\My\$CertThumbprint"
+        $CertExpire = $Cert.NotBefore
 
-        if ($CertThumbprint -notin $oldThumbs) {
+        # find the old thumbprint value for the specified services
+        $OldCertThumbprint = ''
+        $OldCertSubject = ''
+        $OldCertExpire = ''
+        $ExchangeCerts = Get-ExchangeCertificate 
+        $ExchangeCerts | ForEach-Object {
+            $CertServices = $_.Services -split ', '
+            $ServicesDiff = Compare-Object -ReferenceObject $ExchangeServices -DifferenceObject $CertServices
+            if ($ServicesDiff.Length -eq 0) { # No differences? means same services
+                $OldCertThumbprint = $_.Thumbprint.ToString()
+                $OldCertSubject = $_.Subject.ToString()
+                $OldCertExpire = $_.NotAfter
+            }
+        }
 
-            # set the new value
-            Write-Verbose "Setting new Exchange thumbprint value"
-            Enable-ExchangeCertificate -Services $ExchangeServices -Thumbprint $CertThumbprint -Force -EA Stop -Verbose:$false
+        $NewCertInstalled = $false
 
-            # remove the old certs if specified
-            if ($RemoveOldCert) { $oldThumbs | ForEach-Object { Remove-OldCert $_ } }
+        if ($OldCertThumbprint -eq $CertThumbprint) { # Already registered in Exchange?
+
+            Write-Host "Specified certificate ($OldCertSubject, Expiring: $OldCertExpire) is already configured for Exchange services: $ExchangeServices."
 
         } else {
-            Write-Warning "Specified certificate is already configured for Exchange"
+
+            try {
+
+                # set the new value
+                Write-Host "Setting new Exchange thumbprint: $CertThumbprint value Expiring: $CertExpire"
+                Enable-ExchangeCertificate -Services $ExchangeServices -Thumbprint $CertThumbprint -Force -EA Stop -Verbose:$false
+
+                $NewCertInstalled = $true
+
+            } catch { throw }
+
+        }
+
+        # automatically unconfigure old certs for the current service list from Exchange
+        $ExchangeCerts | ForEach-Object {
+            $ThisServices = $_.Services -split ', '
+            $ThisSubject = $_.Subject
+            $ThisNotAfter = $_.NotAfter
+            $ThisThumbprint = $_.Thumbprint
+            $ServicesDiff = Compare-Object -ReferenceObject $ExchangeServices -DifferenceObject $ThisServices
+            if (($ServicesDiff.Length -eq 0) -and ($_.Thumbprint.ToString() -ne $CertThumbprint)) { # Same Services but not just installed
+                Write-Host "Removing certificate ($ThisSubject Expiring: $ThisNotAfter) from the Exchange Configuration. Thumbprint: $ThisThumbprint"
+                Remove-ExchangeCertificate -Thumbprint $_.Thumbprint -Confirm:$false
+                # remove old cert if specified
+                if ($RemoveOldCert) {
+                    Remove-OldCert $_.Thumbprint.ToString()
+                }
+            }
+        }
+
+        if (($NewCertInstalled) -and ('IIS' -in $ExchangeServices)) {
+            $TempFile = New-TemporaryFile
+            $IISCommand = (Get-Command 'iisreset.exe').Path
+            Start-Process -FilePath $IISCommand -ArgumentList '/RESTART' -NoNewWindow -RedirectStandardOutput $TempFile -Wait 
+            Get-Content $TempFile | Write-Host
+            Remove-Item $TempFile
         }
 
     }

--- a/Posh-ACME.Deploy/Public/Set-RASSTPCertificate.ps1
+++ b/Posh-ACME.Deploy/Public/Set-RASSTPCertificate.ps1
@@ -1,0 +1,90 @@
+function Set-RASSTPCertificate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0,ValueFromPipelineByPropertyName)]
+        [Alias('Thumbprint')]
+        [string]$CertThumbprint,
+        [Parameter(Position=1,ValueFromPipelineByPropertyName)]
+        [string]$PfxFile,
+        [Parameter(Position=2,ValueFromPipelineByPropertyName)]
+        [securestring]$PfxPass,
+        [switch]$RemoveOldCert
+    )
+
+    Begin {
+
+        # make sure the Remote Access module is available
+        if (!(Get-Module -ListAvailable RemoteAccess -Verbose:$false)) {
+            throw "The RemoteAccess module is required to use this function."
+        } else {
+            Import-Module RemoteAccess -Verbose:$false
+        }
+    }
+
+    Process {
+    
+        # surface exceptions without terminating the whole pipeline
+        trap { $PSCmdlet.WriteError($PSItem); return }
+
+        $CertThumbprint = Confirm-CertInstall @PSBoundParameters
+
+        $Cert = Get-ChildItem -Path "Cert:\LocalMachine\My\$CertThumbprint"
+
+        # check the old thumbprint value
+        $oldThumb = (Get-RemoteAccess).SslCertificate.Thumbprint
+
+        if ($oldThumb -ne $CertThumbprint) {
+
+            try {
+
+                # set the new value
+                Write-Verbose "Setting new Remote Access SSTP thumbprint value"
+                Stop-Service RemoteAccess
+                Set-RemoteAccess -SslCertificate $Cert
+                Start-Service RemoteAccess
+
+                # remove the old cert if specified
+                if ($RemoveOldCert) { Remove-OldCert $oldThumb }
+
+            } catch { throw }
+
+        } else {
+            Write-Warning "Specified certificate is already configured for the Remote Access SSTP Service"
+        }
+
+    }
+
+    <#
+    .SYNOPSIS
+        Configure Remote Access SSTP service to use the specified certificate.
+
+    .DESCRIPTION
+        Intended to be used with the output from Posh-ACME's New-PACertificate or Submit-Renewal.
+
+    .PARAMETER CertThumbprint
+        Thumbprint/Fingerprint for the certificate to configure.
+
+    .PARAMETER PfxFile
+        Path to a PFX containing a certificate and private key. Not required if the certificate is already in the local system's Personal certificate store.
+
+    .PARAMETER PfxPass
+        The export password for the specified PfxFile parameter. Not required if the Pfx does not require an export password.
+
+    .PARAMETER RemoveOldCert
+        If specified, the old certificate associated with Remote Access SSTP will be deleted from the local system's Personal certificate store. Ignored if the old certificate has already been removed or otherwise can't be found.
+
+    .EXAMPLE
+        New-PACertificate vpn.example.com | Set-RASSTPCertificate
+
+        Create a new certificate and configure it for Remote Access SSTP on this system.
+
+    .EXAMPLE
+        Submit-Renewal vpn.example.com | Set-RASSTPCertificate
+
+        Renew a certificate and configure it for Remote Access SSTP on this system.
+
+    .LINK
+        Project: https://github.com/rmbolger/Posh-ACME.Deploy
+
+    #>
+}


### PR DESCRIPTION
This pull request addresses 2 things:

1) Your most recent commit to this repo (338f757a71d4) inadvertently undid the prior accepted pull request I had submitted and you accepted a couple of months back to Set-ExchangeCertificate.ps1 (3c2b8c341).
2) Additional work on Set-ExchangeCertificate.ps1 to address proper install and optional removal of a replaced certificate from the Exchange configuration.  I didn't notice the need for these changes until renewals had been trying to operate for a couple of months.  After I dug into the details of what was failing, I found that the code path which tried to remove the prior certificate was actually passing a collection of certificate thumbprints rather than the appropriate thumbprint for the certificate that needed to be removed.  The removal routine specifically required a single thumbprint rather than a collection.  As a result, I realized that the logic locating the old certificated needed a rewrite since it didn't find a specific certificated but any certs defined in exchange which mentioned any of the listed ExchangeServices.  The wrong certs that were found were deliberately built-in never externally relevant certs needed by exchange and never publicly facing AND SHOULD NOT be removed.  Exchange environments with needed certs actually default to have a single cert used for IMAP, POP, IIS and SMTP.  I therefore changed the configured default ExchangeServices argument to include all of these.  I then implemented logic to locate an existing configured certificate that was used for the full set of ExchangeServices and then installed the cert specifically for those services and then if the input arguments specifically stated to RemoveOldCert only that cert was removed from the Exchange configuration.

Although the semantics of the parameters to this routine have changed, I can't imagine a real world configuration which worked correctly with the previous code but were just encountering an error which folks didn't notice.
I noticed this as a result of running the Exchange HealthChecker.ps1 script which is recommended to be run regularly to check for configuration inconsistencies.  The output of this script reported the several expired certs lingering in the Exchange configuration which should have been removed by Set-ExchangeCertificate.ps1 with RemoveOldCert enabled.

Maybe Set-ExchangeCertificate.ps1 should be further enriched to also remove all expired certs for the specified services when RemoveOldCert is enabled.  This would then automatically remnants which had been hanging around from previous runs of Set-ExchangeCertificate.ps1 which didn't remove them...  If you want I'll take a stab at that.