### PR TITLE
Added Remote Desktop Listener to Deployment Targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Collection of certificate deployment functions intended for use with [Posh-ACM
 
 - IIS 7.0+
 - IIS FTP services
-- Remote Desktop Session Host
+- Remote Desktop Session Host / Remote Desktop listener
 - Remote Desktop Gateway
 - WinRM
 - Exchange (tested on 2019)


### PR DESCRIPTION
While the certificates documented 
https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds-roles and 
https://learn.microsoft.com/en-us/troubleshoot/windows-server/remote/remote-desktop-listener-certificate-configurations are identical, naming convention can be confusing.