### PR TITLE
Add Active Directory LDAPS deploy

### DIFF
--- a/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
+++ b/Posh-ACME.Deploy/Posh-ACME.Deploy.psd1
@@ -20,6 +20,7 @@ FunctionsToExport = @(
     'Set-RDSHCertificate'
     'Set-WinRMCertificate'
     'Set-NPSCertificate'
+    'Set-ActiveDirectoryLDAPS'
 )
 CmdletsToExport = @()
 VariablesToExport = @()

--- a/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
@@ -33,7 +33,7 @@ function Set-ActiveDirectoryLDAPS {
     
         if ($RemoveOldCert) {
             Get-ChildItem $NtdsCertStore | Select -Expand Name | ForEach-Object {
-                if ($_ -notlike "*$sig*") {
+                if ($_ -notlike "*$CertThumbprint*") {
                     Remove-Item Registry::$_
                 }
             }

--- a/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
@@ -28,7 +28,9 @@ function Set-ActiveDirectoryLDAPS {
         }
 
         # Look for the old cert thumbprint
-        $oldThumbprint = Get-ChildItem $NtdsCertStore | Select-Object -First 1 | Select-Object -Expand PSChildName
+        $oldThumbprint = Get-ChildItem $NtdsCertStore |
+            Where-Object { $_.PSChildName -ne $CertThumbprint } |
+            Select-Object -First 1 -Expand PSChildName
 
         # Copy cert from local store to NTDS Store
         Write-Verbose "Copying cert with thumbprint $CertThumbprint to NTDS cert store."

--- a/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
@@ -1,0 +1,35 @@
+function Set-ActiveDirectoryLDAPS {
+    [CmdletBinding()]
+    param(
+        [Parameter(Position=0,ValueFromPipelineByPropertyName)]
+        [Alias('Thumbprint')]
+        [string]$CertThumbprint,
+        [Parameter(Position=1,ValueFromPipelineByPropertyName)]
+        [string]$PfxFile,
+        [Parameter(Position=2,ValueFromPipelineByPropertyName)]
+        [securestring]$PfxPass,       
+        [switch]$RemoveOldCert # Not used, included due to spec.
+    )
+
+    Process {
+
+        # surface exceptions without terminating the whole pipeline
+        trap { $PSCmdlet.WriteError($PSItem); return }
+
+        $CertThumbprint = Confirm-CertInstall @PSBoundParameters
+        
+        # Copy cert from local store to NTDS Store
+        $LocalCertStore = 'HKLM:/Software/Microsoft/SystemCertificates/My/Certificates'
+        $NtdsCertStore = 'HKLM:/Software/Microsoft/Cryptography/Services/NTDS/SystemCertificates/My/Certificates'
+        if (-Not (Test-Path $NtdsCertStore)) {
+	        New-Item $NtdsCertStore -Force
+        }
+        Copy-Item -Path "$LocalCertStore/$CertThumbprint" -Destination $NtdsCertStore
+        
+        # Command AD to update.
+        $dse = [adsi]'LDAP://localhost/rootDSE'
+        [void]$dse.Properties['renewServerCertificate'].Add(1)
+        $dse.CommitChanges()        
+    }
+
+}

--- a/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
@@ -8,7 +8,7 @@ function Set-ActiveDirectoryLDAPS {
         [string]$PfxFile,
         [Parameter(Position=2,ValueFromPipelineByPropertyName)]
         [securestring]$PfxPass,       
-        [switch]$RemoveOldCert # Not used, included due to spec.
+        [switch]$RemoveOldCert
     )
 
     Process {
@@ -30,6 +30,13 @@ function Set-ActiveDirectoryLDAPS {
         $dse = [adsi]'LDAP://localhost/rootDSE'
         [void]$dse.Properties['renewServerCertificate'].Add(1)
         $dse.CommitChanges()        
+    
+        if ($RemoveOldCert) {
+            Get-ChildItem $NtdsCertStore | Select -Expand Name | ForEach-Object {
+                if ($_ -notlike "*$sig*") {
+                    Remove-Item Registry::$_
+                }
+            }
+        }
     }
-
 }

--- a/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
+++ b/Posh-ACME.Deploy/Public/Set-ActiveDirectoryLDAPS.ps1
@@ -23,24 +23,31 @@ function Set-ActiveDirectoryLDAPS {
         # Make sure the NTDS store exists
         $NtdsCertStore = 'HKLM:/Software/Microsoft/Cryptography/Services/NTDS/SystemCertificates/My/Certificates'
         if (-Not (Test-Path $NtdsCertStore)) {
-	        $null = New-Item $NtdsCertStore -Force
+            Write-Verbose "Existing NTDS cert store not found. Creating the necessary reg key."
+            $null = New-Item $NtdsCertStore -Force
         }
 
         # Look for the old cert thumbprint
         $oldThumbprint = Get-ChildItem $NtdsCertStore | Select-Object -First 1 | Select-Object -Expand PSChildName
 
         # Copy cert from local store to NTDS Store
+        Write-Verbose "Copying cert with thumbprint $CertThumbprint to NTDS cert store."
         Copy-Item -Path "$LocalCertStore/$CertThumbprint" -Destination $NtdsCertStore
 
-        # Remove old copies if necessary
-        if ($RemoveOldCert -and $oldThumbprint) {
-            Get-ChildItem $NtdsCertStore | Where-Object { $_.PSChildName -eq $oldThumbprint } | Remove-Item
-            Get-ChildItem $LocalCertStore | Where-Object { $_.PSChildName -eq $oldThumbprint } | Remove-Item
-        }
+        # Remove all certs except the new one from the NTDS store
+        Write-Verbose "Removing certs not matching thumbprint $CertThumbprint from NTDS cert store."
+        Get-ChildItem $NtdsCertStore | Where-Object { $_.PSChildName -ne $CertThumbprint } | Remove-Item
 
         # Command AD to update.
+        Write-Verbose "Triggering NTDS cert update."
         $dse = [adsi]'LDAP://localhost/rootDSE'
         [void]$dse.Properties['renewServerCertificate'].Add(1)
         $dse.CommitChanges()
+
+        # Remove the old cert from LocalMachine if asked to
+        if ($RemoveOldCert -and $oldThumbprint) {
+            Write-Verbose "Removing old cert with thumbprint $oldThumbprint from Local Machine cert store."
+            Get-ChildItem $LocalCertStore | Where-Object { $_.PSChildName -eq $oldThumbprint } | Remove-Item
+        }
     }
 }

--- a/Posh-ACME.Deploy/en-US/Posh-ACME.Deploy-help.xml
+++ b/Posh-ACME.Deploy/en-US/Posh-ACME.Deploy-help.xml
@@ -2,6 +2,145 @@
 <helpItems schema="maml" xmlns="http://msh">
   <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
     <command:details>
+      <command:name>Set-ActiveDirectoryLDAPS</command:name>
+      <command:verb>Set</command:verb>
+      <command:noun>ActiveDirectoryLDAPS</command:noun>
+      <maml:description>
+        <maml:para>Configure Active Directory Domain Services (ADDS) certificate.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>In cases where ADDS does not automatically pick up the LDAPS certificate from the Local Computer cert store, it can be necessary to explicitly import the cert into the NTDS Service store. Intended to be used with the output from Posh-ACME's New-PACertificate or Submit-Renewal.</maml:para>
+      <maml:para>This requires elevated/admin access on the domain controller.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem>
+        <maml:name>Set-ActiveDirectoryLDAPS</maml:name>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="Thumbprint">
+          <maml:name>CertThumbprint</maml:name>
+          <maml:description>
+            <maml:para>Thumbprint/Fingerprint for the certificate to configure.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+          <maml:name>PfxFile</maml:name>
+          <maml:description>
+            <maml:para>Path to a PFX containing a certificate and private key. Not required if the certificate is already in the local system's Personal certificate store.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+          <maml:name>PfxPass</maml:name>
+          <maml:description>
+            <maml:para>The export password for the specified PfxFile parameter. Not required if the Pfx does not require an export password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+          <dev:type>
+            <maml:name>SecureString</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+          <maml:name>RemoveOldCert</maml:name>
+          <maml:description>
+            <maml:para>If specified, the old certificate will be deleted from the local system's Personal certificate store. Ignored if the old certificate has already been removed or otherwise can't be found.</maml:para>
+          </maml:description>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>False</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="0" aliases="Thumbprint">
+        <maml:name>CertThumbprint</maml:name>
+        <maml:description>
+          <maml:para>Thumbprint/Fingerprint for the certificate to configure.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="1" aliases="none">
+        <maml:name>PfxFile</maml:name>
+        <maml:description>
+          <maml:para>Path to a PFX containing a certificate and private key. Not required if the certificate is already in the local system's Personal certificate store.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByPropertyName)" position="2" aliases="none">
+        <maml:name>PfxPass</maml:name>
+        <maml:description>
+          <maml:para>The export password for the specified PfxFile parameter. Not required if the Pfx does not require an export password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SecureString</command:parameterValue>
+        <dev:type>
+          <maml:name>SecureString</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="none">
+        <maml:name>RemoveOldCert</maml:name>
+        <maml:description>
+          <maml:para>If specified, the old certificate will be deleted from the local system's Personal certificate store. Ignored if the old certificate has already been removed or otherwise can't be found.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>False</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes />
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert />
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>-------------------------- EXAMPLE 1 --------------------------</maml:title>
+        <dev:code>$dc = Get-ADDomainController -Discover
+$domains = $dc.HostName, $dc.Domain
+New-PACertificate $domains | Set-ActiveDirectoryLDAPS -RemoveOldCert</dev:code>
+        <dev:remarks>
+          <maml:para>Create a new certificate for the DC and domain's FQDNs and add configure Active Directory to use it for LDAPS.</maml:para>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks>
+      <maml:navigationLink>
+        <maml:linkText>Online Version:</maml:linkText>
+        <maml:uri>https://docs.dvolve.net/Posh-ACME.Deploy/v2/Functions/Set-ActiveDirectoryLDAPS/</maml:uri>
+      </maml:navigationLink>
+    </command:relatedLinks>
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp">
+    <command:details>
       <command:name>Set-ExchangeCertificate</command:name>
       <command:verb>Set</command:verb>
       <command:noun>ExchangeCertificate</command:noun>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Collection of certificate deployment functions intended for use with [Posh-ACM
 - Exchange (tested on 2019)
 - [Network Policy Server (NPS)](https://docs.microsoft.com/en-us/windows-server/networking/technologies/nps/nps-top)
 - Remote Access SSTP
+- Active Directory (LDAPS)
 
 ## Installation (Stable)
 

--- a/docs/Functions/Set-ActiveDirectoryLDAPS.md
+++ b/docs/Functions/Set-ActiveDirectoryLDAPS.md
@@ -1,0 +1,106 @@
+---
+external help file: Posh-ACME.Deploy-help.xml
+Module Name: Posh-ACME.Deploy
+online version: https://docs.dvolve.net/Posh-ACME.Deploy/v2/Functions/Set-ActiveDirectoryLDAPS/
+schema: 2.0.0
+---
+
+# Set-ActiveDirectoryLDAPS
+
+## Synopsis
+
+Configure Active Directory Domain Services (ADDS) certificate.
+
+## Syntax
+
+```powershell
+Set-ActiveDirectoryLDAPS [[-CertThumbprint] <String>] [[-PfxFile] <String>] [[-PfxPass] <SecureString>]
+ [-RemoveOldCert] [<CommonParameters>]
+```
+
+## Description
+
+In cases where ADDS does not automatically pick up the LDAPS certificate from the Local Computer cert store, it can be necessary to explicitly import the cert into the NTDS Service store. Intended to be used with the output from Posh-ACME's New-PACertificate or Submit-Renewal.
+
+This requires elevated/admin access on the domain controller.
+
+## Examples
+
+### EXAMPLE 1
+```
+$dc = Get-ADDomainController -Discover
+$domains = $dc.HostName, $dc.Domain
+New-PACertificate $domains | Set-ActiveDirectoryLDAPS -RemoveOldCert
+```
+
+Create a new certificate for the DC and domain's FQDNs and add configure Active Directory to use it for LDAPS.
+
+## Parameters
+
+### -CertThumbprint
+Thumbprint/Fingerprint for the certificate to configure.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: Thumbprint
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PfxFile
+Path to a PFX containing a certificate and private key.
+Not required if the certificate is already in the local system's Personal certificate store.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -PfxPass
+The export password for the specified PfxFile parameter.
+Not required if the Pfx does not require an export password.
+
+```yaml
+Type: SecureString
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByPropertyName)
+Accept wildcard characters: False
+```
+
+### -RemoveOldCert
+If specified, the old certificate will be deleted from the local system's Personal certificate store.
+Ignored if the old certificate has already been removed or otherwise can't be found.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## Related Links


### PR DESCRIPTION
This adds `Set-ActiveDirectoryLDAPS` to the module. Since AD is opinionated (IE domain has to be correct), but the deploy requires that a set of common params be sent: I am leaving it up to the user to get right.

Usage is the same as most of the other modules, however in order to get the correct cert I would recommend this:
```powershell
# Create the certificate
$dc = Get-ADDomainController -Discover
$domains = $dc.HostName, $dc.Domain

New-PACertificate -Domain $domains | Set-ActiveDirectoryLDAPS -Verbose -RemoveOldCert
```